### PR TITLE
internal/cmd: Fix -ignore flag in go generate matches unexpected files

### DIFF
--- a/internal/cmd/coreutils/bindata.go
+++ b/internal/cmd/coreutils/bindata.go
@@ -20,7 +20,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -28,7 +28,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err

--- a/internal/cmd/coreutils/main.go
+++ b/internal/cmd/coreutils/main.go
@@ -30,7 +30,7 @@ type metadata struct {
 	Storage map[string]map[string]bool `json:"storage"`
 }
 
-//go:generate go-bindata -nometadata -ignore ".go$" -prefix tmpl ./tmpl
+//go:generate go-bindata -nometadata -ignore "\\.go$" -prefix tmpl ./tmpl
 func main() {
 	f, err := os.Create(generatedPath)
 	if err != nil {

--- a/internal/cmd/coreutils/main.go
+++ b/internal/cmd/coreutils/main.go
@@ -30,7 +30,7 @@ type metadata struct {
 	Storage map[string]map[string]bool `json:"storage"`
 }
 
-//go:generate go-bindata -nometadata -ignore ".*.go" -prefix tmpl ./tmpl
+//go:generate go-bindata -nometadata -ignore ".go$" -prefix tmpl ./tmpl
 func main() {
 	f, err := os.Create(generatedPath)
 	if err != nil {

--- a/internal/cmd/metadata/bindata.go
+++ b/internal/cmd/metadata/bindata.go
@@ -20,7 +20,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -28,7 +28,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err

--- a/internal/cmd/metadata/main.go
+++ b/internal/cmd/metadata/main.go
@@ -18,7 +18,7 @@ var (
 			Parse(string(MustAsset("metadata.tmpl"))))
 )
 
-//go:generate go-bindata -nometadata -ignore ".go$" .
+//go:generate go-bindata -nometadata -ignore "\\.go$" .
 func main() {
 	fi, err := ioutil.ReadDir(".")
 	if err != nil {

--- a/internal/cmd/metadata/main.go
+++ b/internal/cmd/metadata/main.go
@@ -18,7 +18,7 @@ var (
 			Parse(string(MustAsset("metadata.tmpl"))))
 )
 
-//go:generate go-bindata -nometadata -ignore ".*.go" .
+//go:generate go-bindata -nometadata -ignore ".go$" .
 func main() {
 	fi, err := ioutil.ReadDir(".")
 	if err != nil {

--- a/internal/cmd/pairs/bindata.go
+++ b/internal/cmd/pairs/bindata.go
@@ -20,7 +20,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -28,7 +28,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err

--- a/internal/cmd/pairs/main.go
+++ b/internal/cmd/pairs/main.go
@@ -23,7 +23,7 @@ type Pairs map[string]struct {
 	Description string
 }
 
-//go:generate go-bindata -nometadata -ignore ".*.go" .
+//go:generate go-bindata -nometadata -ignore ".go$" .
 func main() {
 	pairsPath := "pairs.json"
 	content, err := ioutil.ReadFile(pairsPath)

--- a/internal/cmd/pairs/main.go
+++ b/internal/cmd/pairs/main.go
@@ -23,7 +23,7 @@ type Pairs map[string]struct {
 	Description string
 }
 
-//go:generate go-bindata -nometadata -ignore ".go$" .
+//go:generate go-bindata -nometadata -ignore "\\.go$" .
 func main() {
 	pairsPath := "pairs.json"
 	content, err := ioutil.ReadFile(pairsPath)

--- a/internal/cmd/service/bindata.go
+++ b/internal/cmd/service/bindata.go
@@ -23,7 +23,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -31,7 +31,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err

--- a/internal/cmd/service/main.go
+++ b/internal/cmd/service/main.go
@@ -31,7 +31,7 @@ var (
 			Parse(string(MustAsset("pairs.tmpl"))))
 )
 
-//go:generate go-bindata -nometadata -ignore ".*.go" -prefix tmpl ./tmpl
+//go:generate go-bindata -nometadata -ignore ".go$" -prefix tmpl ./tmpl
 func main() {
 	f, err := os.Create(generatedPath)
 	if err != nil {

--- a/internal/cmd/service/main.go
+++ b/internal/cmd/service/main.go
@@ -31,7 +31,7 @@ var (
 			Parse(string(MustAsset("pairs.tmpl"))))
 )
 
-//go:generate go-bindata -nometadata -ignore ".go$" -prefix tmpl ./tmpl
+//go:generate go-bindata -nometadata -ignore "\\.go$" -prefix tmpl ./tmpl
 func main() {
 	f, err := os.Create(generatedPath)
 	if err != nil {


### PR DESCRIPTION
The `ignore` flag in [go-bindata](https://github.com/kevinburke/go-bindata) works as regexp. However, it works differently with `prefix` flag set or not. When `prefix` flag set, the input path would be parsed into abs path, so `ignore` flag may work with your own directory.
So this PR makes the `ignore` regexp more accurate.

ref: [issue in go-bindata](https://github.com/kevinburke/go-bindata/issues/30)